### PR TITLE
Update default ToolBench service url to http://39.105.143.28:8080/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You need to first specify your configurations in `server/config.yml` before runn
  - `api_base`: The API base for OpenAI models if you are using Azure.
  - `model`: The OpenAI model to use. The default value is gpt-4-turbo-preview.
  - `temperature`: The temperature for LLM simulation. The default value is 0.
- - `toolbench_url`: The real ToolBench server URL. The default value is `http://8.218.239.54:8080/rapidapi`.
+ - `toolbench_url`: The real ToolBench server URL. The default value is `http://39.105.143.28:8080/rapidapi`.
  - `tools_folder`: The tools environment folder path. Default to `./tools`.
  - `cache_folder`: The cache folder path. Default to `./tool_response_cache`.
  - `is_save`: A flag to indicate whether to save real and simulated responses into the cache. The new cache is saved at `./tool_response_new_cache`.

--- a/server/config.yml
+++ b/server/config.yml
@@ -2,7 +2,7 @@ api_key:
 api_base:
 model: gpt-4-turbo
 temperature: 0
-toolbench_url: http://8.218.239.54:8080/rapidapi
+toolbench_url: http://39.105.143.28:8080/rapidapi
 tools_folder: "./tools"
 cache_folder: "./tool_response_cache"
 is_save: true

--- a/toolbench/inference/Downstream_tasks/rapidapi.py
+++ b/toolbench/inference/Downstream_tasks/rapidapi.py
@@ -61,7 +61,7 @@ class rapidapi_wrapper(base_env):
         self.rapidapi_key = args.rapidapi_key
         self.use_rapidapi_key = args.use_rapidapi_key
         self.api_customization = args.api_customization
-        self.service_url = os.getenv("SERVICE_URL", "http://8.218.239.54:8080/rapidapi")
+        self.service_url = os.getenv("SERVICE_URL", "http://39.105.143.28:8080/rapidapi")
         self.max_observation_length = args.max_observation_length
         self.observ_compress_method = args.observ_compress_method
         self.retriever = retriever

--- a/toolbench/inference/Downstream_tasks/rapidapi_multithread.py
+++ b/toolbench/inference/Downstream_tasks/rapidapi_multithread.py
@@ -62,7 +62,7 @@ class rapidapi_wrapper(base_env):
         self.rapidapi_key = args.rapidapi_key
         self.use_rapidapi_key = args.use_rapidapi_key
         self.api_customization = args.api_customization
-        self.service_url = os.getenv("SERVICE_URL", "http://8.218.239.54:8080/rapidapi")
+        self.service_url = os.getenv("SERVICE_URL", "http://39.105.143.28:8080/rapidapi")
         self.max_observation_length = args.max_observation_length
         self.observ_compress_method = args.observ_compress_method
         self.retriever = retriever


### PR DESCRIPTION
It looks like ToolBench moved their service URL to `http://39.105.143.28:8080/rapidapi`, so I thought it might make sense to update these defaults in StableToolBench.

See [this commit](https://github.com/OpenBMB/ToolBench/commit/6a0af3f48e31aed9a4a1ac3143f38d2e7cdd909a) in the ToolBench repo.